### PR TITLE
Fix formatting of downloaded README.md

### DIFF
--- a/front-end/readme-assist-tool/src/pages/Composer/READMEContainer/READMEContainer.jsx
+++ b/front-end/readme-assist-tool/src/pages/Composer/READMEContainer/READMEContainer.jsx
@@ -50,6 +50,7 @@ function markdownHeaderToHTML(section) {
     <div key={key}>
       {header}
       {exampleLink}
+      <br/>
     </div>
   );
 }


### PR DESCRIPTION
Adding a line break between sections seems to address this.

Before:
```markdown
# Project Name

> tagline

![header](image)

## Features
[//]: # (https://github.com/WenchaoD/FSPagerView#Features)
### Kingfisher 101
[//]: # (https://github.com/onevcat/Kingfisher#Kingfisher-101)
## About
[//]: # (https://github.com/philackm/ScrollableGraphView#About)
## Overview
[//]: # (https://github.com/airbnb/Lona#Overview)
```

After:
```markdown
# Project Name

> tagline

![header](image)

## Features
[//]: # (https://github.com/WenchaoD/FSPagerView#Features)

### Kingfisher 101
[//]: # (https://github.com/onevcat/Kingfisher#Kingfisher-101)

## About
[//]: # (https://github.com/philackm/ScrollableGraphView#About)

## Overview
[//]: # (https://github.com/airbnb/Lona#Overview)

```